### PR TITLE
limit range to first 20kb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 
 # misc
 .DS_Store
+/.vscode
 .env.local
 .env.development.local
 .env.test.local

--- a/src/services/getDappMetadata.js
+++ b/src/services/getDappMetadata.js
@@ -36,7 +36,7 @@ export default async function getDappMetadata(skylink) {
 
   try {
     const skylinkUrl = await skynetClient.getSkylinkUrl(skylink, { subdomain: true });
-    const response = await ky.get(skylinkUrl);
+    const response = await ky.get(skylinkUrl, { headers: { range: "bytes=0-20000" } });
     const contentType = response.headers.get("content-type");
 
     if (contentType !== "text/html") {

--- a/src/services/getDappMetadata.js
+++ b/src/services/getDappMetadata.js
@@ -36,8 +36,7 @@ export default async function getDappMetadata(skylink) {
 
   try {
     const skylinkUrl = await skynetClient.getSkylinkUrl(skylink, { subdomain: true });
-    const response = await ky.get(skylinkUrl, { headers: { range: "bytes=0-20000" } });
-    const contentType = response.headers.get("content-type");
+    const contentType = (await ky.head(skylinkUrl)).headers.get("content-type");
 
     if (contentType !== "text/html") {
       return { ...emptyManifest, ...skynetMetadata };
@@ -47,7 +46,7 @@ export default async function getDappMetadata(skylink) {
     // TODO: replace with client.getFileContent() for registry verification on resolver skylinks
 
     // Grab HTML and parse. Used to find manifest URL and metadata.
-    const responseText = await response.text();
+    const responseText = await ky.get(skylinkUrl).text();
     const parser = new DOMParser();
     const doc = parser.parseFromString(responseText, "text/html");
 


### PR DESCRIPTION
Currently, we do a GET request to the skylink. As we move to fully-verified registry entries, we won't need to make resolve or metadata requests, so we won't be able to use logic from them to know if we should call "GET" or "HEAD". This solves that by assuming that any HTML file will be <20k, and any other file can exit early since the needed info is in the response headers.

Also added `.vscode` folder to .gitignore