### PR TITLE
Store manifestPath in homescreen

### DIFF
--- a/src/components/InstallFromSkylinkModal.js
+++ b/src/components/InstallFromSkylinkModal.js
@@ -100,6 +100,7 @@ export default function InstallFromSkylinkModal() {
           if (metadata.description) data.metadata.description = metadata.description;
           if (metadata.themeColor) data.metadata.themeColor = metadata.themeColor;
           if (metadata.icon) data.metadata.icon = metadata.icon;
+          if (metadata.manifestPath) data.manifestPath = metadata.manifestPath;
 
           // if resolved skylink is included in metadata then use it
           if (metadata.skylink && isSkylinkV2(metadata.skylink)) data.resolverSkylink = metadata.skylink;

--- a/src/services/getDappMetadata.js
+++ b/src/services/getDappMetadata.js
@@ -71,7 +71,7 @@ export default async function getDappMetadata(skylink) {
     const parsedMetadata = await parseMetadata(responseText, doc, skylinkUrl);
 
     // combine results from parsers, with Manifest taking priority
-    return { ...emptyManifest, ...skynetMetadata, ...parsedMetadata, skylink, ...parsedManifest };
+    return { ...emptyManifest, ...skynetMetadata, ...parsedMetadata, skylink, manifestPath, ...parsedManifest };
   } catch (error) {
     console.error(error.message);
 
@@ -93,10 +93,9 @@ function parseManifest(manifest, manifestUrl) {
   const icon = get(manifest.icons, ["0", "src"]) || manifest.iconPath || undefined;
   const iconUrl = icon ? new URL(icon, manifestUrl).pathname : undefined;
   const skylink = cleanSkylink(manifest.skylink) || undefined;
-  const skynetMetadata = manifest.skynet_metadata || undefined;
 
   // return parsed after removing undefined keys.
-  return JSON.parse(JSON.stringify({ name: chosenName, icon: iconUrl, description, themeColor, skylink, skynetMetadata }));
+  return JSON.parse(JSON.stringify({ name: chosenName, icon: iconUrl, description, themeColor, skylink }));
 }
 
 // Use index.html metadata fields to fill out missing Dapp Data

--- a/src/services/getDappMetadata.js
+++ b/src/services/getDappMetadata.js
@@ -93,10 +93,10 @@ function parseManifest(manifest, manifestUrl) {
   const icon = get(manifest.icons, ["0", "src"]) || manifest.iconPath || undefined;
   const iconUrl = icon ? new URL(icon, manifestUrl).pathname : undefined;
   const skylink = cleanSkylink(manifest.skylink) || undefined;
-  const skyos = manifest.skyos || undefined;
+  const skynetMetadata = manifest.skynet_metadata || undefined;
 
   // return parsed after removing undefined keys.
-  return JSON.parse(JSON.stringify({ name: chosenName, icon: iconUrl, description, themeColor, skylink, skyos }));
+  return JSON.parse(JSON.stringify({ name: chosenName, icon: iconUrl, description, themeColor, skylink, skynetMetadata }));
 }
 
 // Use index.html metadata fields to fill out missing Dapp Data

--- a/src/services/getDappMetadata.js
+++ b/src/services/getDappMetadata.js
@@ -93,9 +93,10 @@ function parseManifest(manifest, manifestUrl) {
   const icon = get(manifest.icons, ["0", "src"]) || manifest.iconPath || undefined;
   const iconUrl = icon ? new URL(icon, manifestUrl).pathname : undefined;
   const skylink = cleanSkylink(manifest.skylink) || undefined;
+  const skyos = manifest.skyos || undefined;
 
   // return parsed after removing undefined keys.
-  return JSON.parse(JSON.stringify({ name: chosenName, icon: iconUrl, description, themeColor, skylink }));
+  return JSON.parse(JSON.stringify({ name: chosenName, icon: iconUrl, description, themeColor, skylink, skyos }));
 }
 
 // Use index.html metadata fields to fill out missing Dapp Data


### PR DESCRIPTION
# Add support for SkyOS metadata in manifest

## Overview

This PR adds support for a new optional `skyos` field in the manifest file of a web app added to Homescreen. Similar to the `skylink` field, it extends the metadata of a default manifest file. The `skyos` field will be used for SkyOS-specific data that skapps want to specify. It will be used to specify url-handlers (which skapp can for example view a MySky user profile?), preferred window sizes, positions and count and other metadata. This `skyos` metadata can also be useful for other skapps (like Rift), not just SkyOS.

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [ ] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created
