### PR TITLE
prevent storage writes before storage is initialised

### DIFF
--- a/src/state/StorageContext.js
+++ b/src/state/StorageContext.js
@@ -80,7 +80,7 @@ export default function StorageContextProvider({ children }) {
   const { mySky, user } = React.useContext(AuthContext);
   const [state, setState] = React.useState(initialState);
   const { dapps, isStorageProcessing, isStorageInitialised } = state;
-  const preventParallelStorageAccess = isStorageProcessing || isStorageInitialised;
+  const preventParallelStorageAccess = isStorageProcessing || !isStorageInitialised;
 
   const refreshStorage = React.useCallback(async () => {
     try {

--- a/src/state/StorageContext.js
+++ b/src/state/StorageContext.js
@@ -79,7 +79,8 @@ const defaultDapps = [
 export default function StorageContextProvider({ children }) {
   const { mySky, user } = React.useContext(AuthContext);
   const [state, setState] = React.useState(initialState);
-  const { dapps, isStorageProcessing } = state;
+  const { dapps, isStorageProcessing, isStorageInitialised } = state;
+  const preventParallelStorageAccess = isStorageProcessing || isStorageInitialised;
 
   const refreshStorage = React.useCallback(async () => {
     try {
@@ -141,7 +142,7 @@ export default function StorageContextProvider({ children }) {
 
   const removeDapp = React.useCallback(
     async (id) => {
-      if (isStorageProcessing) {
+      if (preventParallelStorageAccess) {
         toast.error(storageConsistencyMessage);
         return;
       }
@@ -152,12 +153,12 @@ export default function StorageContextProvider({ children }) {
 
       setState((state) => ({ ...state, isStorageProcessing: false }));
     },
-    [isStorageProcessing, dapps, persistStorage]
+    [preventParallelStorageAccess, dapps, persistStorage]
   );
 
   const updateDapp = React.useCallback(
     async (data) => {
-      if (isStorageProcessing) {
+      if (preventParallelStorageAccess) {
         toast.error(storageConsistencyMessage);
         return;
       }
@@ -182,7 +183,7 @@ export default function StorageContextProvider({ children }) {
 
       setState((state) => ({ ...state, isStorageProcessing: false }));
     },
-    [isStorageProcessing, dapps, persistStorage]
+    [preventParallelStorageAccess, dapps, persistStorage]
   );
 
   const storageContext = React.useMemo(() => {


### PR DESCRIPTION
The bug is most likely caused by race condition when app is trying to write to storage before the storage is initialised. This pull request prevents user triggered writes before the storage is initialised.

closes https://github.com/SkynetLabs/homescreen/issues/51