### PR TITLE
Check `x-ipfs-root-cid` header

### DIFF
--- a/src/services/searchSkylink.js
+++ b/src/services/searchSkylink.js
@@ -129,7 +129,7 @@ function ensureValidUrl(input) {
 
 async function getSkylinkFromHeaders(address) {
   try {
-    const response = await ky.head(address, { credentials: "include" });
+    const response = await ky.head(address);
 
     // check for `skynet-skylink` header
     const skylink = response.headers.get("skynet-skylink");
@@ -139,33 +139,8 @@ async function getSkylinkFromHeaders(address) {
     const cid = response.headers.get("x-ipfs-root-cid");
     if (cid) return migrateIpfsToSkylink(cid);
   } catch (error) {
-    console.log(error);
-    if (error && error.response) {
-      console.log(error.response.data);
-      console.log(error.response.status);
-      console.log(error.response.headers);
-    }
-
-    console.log("trying without credentials...");
-    try {
-      const response = await ky.head(address);
-      console.log('success!', response.headers)
-      // check for `skynet-skylink` header
-      const skylink = response.headers.get("skynet-skylink");
-      if (skylink) return skylink;
-
-      // check for `x-ipfs-root-cid` header
-      const cid = response.headers.get("x-ipfs-root-cid");
-      if (cid) return migrateIpfsToSkylink(cid);
-    } catch (error) {
-      console.log(error);
-      if (error && error.response) {
-        console.log(error.response.data);
-        console.log(error.response.status);
-        console.log(error.response.headers);
-      }
-    }
-    return null;
+    // do nothing
+    return null
   }
 }
 

--- a/src/services/searchSkylink.js
+++ b/src/services/searchSkylink.js
@@ -149,6 +149,7 @@ async function getSkylinkFromHeaders(address) {
     console.log("trying without credentials...");
     try {
       const response = await ky.head(address);
+      console.log('success!', response.headers)
       // check for `skynet-skylink` header
       const skylink = response.headers.get("skynet-skylink");
       if (skylink) return skylink;

--- a/src/services/searchSkylink.js
+++ b/src/services/searchSkylink.js
@@ -80,20 +80,6 @@ export default async function searchSkylink(input) {
     }
   }
 
-  // any arbitrary url
-  if (input.startsWith("https://")) {
-    const skylink = await requestSkylink(input);
-
-    if (skylink) return skylink;
-  }
-
-  if (input.match(/^[^./]+$/)) {
-    const address = await skynetClient.getHnsUrl(input);
-    const skylink = await requestSkylink(address);
-
-    if (skylink) return skylink;
-  }
-
   if (input.match(IPNS_MATCHER)) {
     try {
       const { groups } = input.match(IPNS_MATCHER);
@@ -112,6 +98,22 @@ export default async function searchSkylink(input) {
     if (skylink) return skylink;
   }
 
+  // as last resort, try and do a HEAD call and check whether the response
+  // includes either a `skynet-skylink` or `x-ipfs-root-cid` response header
+  try {
+    const response = await ky.head(address, { credentials: "include" });
+
+    // check for `skynet-skylink` header
+    const skylink = response.headers.get("skynet-skylink");
+    if (skylink) return skylink;
+
+    // check for `x-ipfs-root-cid` header
+    const cid = response.headers.get("x-ipfs-root-cid");
+    if (cid) return migrateIpfsToSkylink(cid);
+  } catch(error) {
+    // do nothing
+  }
+
   return null;
 }
 
@@ -121,9 +123,6 @@ async function requestSkylink(address) {
     const skylink = response.headers.get("skynet-skylink");
 
     if (skylink) return skylink;
-
-    const cid = response.headers.get("x-ipfs-root-cid");
-    if (cid) return migrateIpfsToSkylink(cid);
   } catch {
     return null;
   }

--- a/src/services/searchSkylink.js
+++ b/src/services/searchSkylink.js
@@ -138,6 +138,23 @@ async function getSkylinkFromHeaders(address) {
     console.log(error.response.data);
     console.log(error.response.status);
     console.log(error.response.headers);
+
+    console.log('trying without credentials...')
+    try {
+      const response = await ky.head(address);
+      // check for `skynet-skylink` header
+      const skylink = response.headers.get("skynet-skylink");
+      if (skylink) return skylink;
+
+      // check for `x-ipfs-root-cid` header
+      const cid = response.headers.get("x-ipfs-root-cid");
+      if (cid) return migrateIpfsToSkylink(cid);
+    } catch(error) {
+      console.log(error);
+      console.log(error.response.data);
+      console.log(error.response.status);
+      console.log(error.response.headers);
+    }
     return null;
   }
 }

--- a/src/services/searchSkylink.js
+++ b/src/services/searchSkylink.js
@@ -133,7 +133,11 @@ async function getSkylinkFromHeaders(address) {
     // check for `x-ipfs-root-cid` header
     const cid = response.headers.get("x-ipfs-root-cid");
     if (cid) return migrateIpfsToSkylink(cid);
-  } catch {
+  } catch (error) {
+    console.log(error);
+    console.log(error.response.data);
+    console.log(error.response.status);
+    console.log(error.response.headers);
     return null;
   }
 }

--- a/src/services/searchSkylink.js
+++ b/src/services/searchSkylink.js
@@ -109,7 +109,7 @@ export default async function searchSkylink(input) {
 
   if (input.match(IPFS_CID_MATCHER)) {
     const { groups } = input.match(IPFS_CID_MATCHER);
-    const skylink = migrateIpfsToSkylink(groups.cid);
+    const skylink = await migrateIpfsToSkylink(groups.cid);
 
     if (skylink) return skylink;
   }
@@ -126,7 +126,7 @@ async function requestSkylink(address) {
     if (skylink) return skylink;
 
     // check for `x-ipfs-root-cid` header
-    const cid = response.headers.get("skynet-skylink");
+    const cid = response.headers.get("x-ipfs-root-cid");
     if (cid) return migrateIpfsToSkylink(cid);
   } catch {
     return null;

--- a/src/services/searchSkylink.js
+++ b/src/services/searchSkylink.js
@@ -135,9 +135,11 @@ async function getSkylinkFromHeaders(address) {
     if (cid) return migrateIpfsToSkylink(cid);
   } catch (error) {
     console.log(error);
-    console.log(error.response.data);
-    console.log(error.response.status);
-    console.log(error.response.headers);
+    if (error && error.response) {
+      console.log(error.response.data);
+      console.log(error.response.status);
+      console.log(error.response.headers);
+    }
 
     console.log('trying without credentials...')
     try {
@@ -151,9 +153,11 @@ async function getSkylinkFromHeaders(address) {
       if (cid) return migrateIpfsToSkylink(cid);
     } catch(error) {
       console.log(error);
-      console.log(error.response.data);
-      console.log(error.response.status);
-      console.log(error.response.headers);
+      if (error && error.response) {
+        console.log(error.response.data);
+        console.log(error.response.status);
+        console.log(error.response.headers);
+      }
     }
     return null;
   }

--- a/src/services/searchSkylink.js
+++ b/src/services/searchSkylink.js
@@ -45,6 +45,15 @@ export default async function searchSkylink(input) {
     if (skylink) return skylink;
   }
 
+  // the following matches any string without dots and checks whether they're
+  // hns domains, this catches input like 'uniswap' or 'skyfeed'
+  if (input.match(/^[^./]+$/)) {
+    const address = await skynetClient.getHnsUrl(input);
+    const skylink = await requestSkylink(address);
+
+    if (skylink) return skylink;
+  }
+
   if (input.match(ETH_DOMAIN_MATCHER)) {
     const { groups } = input.match(ETH_DOMAIN_MATCHER);
     const skylink = await requestSkylink(`https://${groups.domain}.eth.link`);

--- a/src/services/searchSkylink.js
+++ b/src/services/searchSkylink.js
@@ -107,7 +107,7 @@ export default async function searchSkylink(input) {
 
   if (input.match(IPFS_CID_MATCHER)) {
     const { groups } = input.match(IPFS_CID_MATCHER);
-    const skylink = migrateIpfsToSkylink(groups.cid);
+    const skylink = await migrateIpfsToSkylink(groups.cid);
 
     if (skylink) return skylink;
   }
@@ -121,6 +121,9 @@ async function requestSkylink(address) {
     const skylink = response.headers.get("skynet-skylink");
 
     if (skylink) return skylink;
+
+    const cid = response.headers.get("x-ipfs-root-cid");
+    if (cid) return migrateIpfsToSkylink(cid);
   } catch {
     return null;
   }


### PR DESCRIPTION
# PULL REQUEST

## Overview

This PR checks the response from the `HEAD` call for the `x-ipfs-root-cid` header.
If present we can use it to migrate the CID to Skynet and return a skylink.

## Example for Visual Changes
N/A

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
N/A